### PR TITLE
[HOLD] Add codemod to drop non-connection lists.

### DIFF
--- a/src/__testfixtures__/remove-non-connection-pageable-graphql-lists.input.ts
+++ b/src/__testfixtures__/remove-non-connection-pageable-graphql-lists.input.ts
@@ -1,0 +1,51 @@
+import {
+  GraphQLFieldConfigMap,
+  GraphQLList,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLObjectType,
+} from "graphql"
+
+export const fields: GraphQLFieldConfigMap<any, any> = {
+  artworks: {
+    type: new GraphQLList(GraphQLString),
+    args: {
+      size: {
+        type: GraphQLInt,
+      },
+    },
+  },
+  artworksConnection: {
+    type: new GraphQLObjectType({
+      name: "ArtworksConnection",
+      fields: {},
+    }),
+    args: {
+      first: {
+        type: GraphQLInt,
+      },
+    },
+  },
+  articles: {
+    type: new GraphQLList(GraphQLString),
+    args: {
+      limit: {
+        type: GraphQLInt,
+      },
+    },
+  },
+  articles_connection: {
+    type: new GraphQLObjectType({
+      name: "ArticlesConnection",
+      fields: {},
+    }),
+    args: {
+      first: {
+        type: GraphQLInt,
+      },
+    },
+  },
+  other: {
+    type: new GraphQLList(GraphQLString),
+  },
+}

--- a/src/__testfixtures__/remove-non-connection-pageable-graphql-lists.output.ts
+++ b/src/__testfixtures__/remove-non-connection-pageable-graphql-lists.output.ts
@@ -1,0 +1,37 @@
+import {
+  GraphQLFieldConfigMap,
+  GraphQLList,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLObjectType,
+} from "graphql"
+
+export const fields: GraphQLFieldConfigMap<any, any> = {
+  artworks: {
+    type: new GraphQLObjectType({
+      name: "ArtworksConnection",
+      fields: {},
+    }),
+    args: {
+      first: {
+        type: GraphQLInt,
+      },
+    },
+  },
+
+  articles: {
+    type: new GraphQLObjectType({
+      name: "ArticlesConnection",
+      fields: {},
+    }),
+    args: {
+      first: {
+        type: GraphQLInt,
+      },
+    },
+  },
+
+  other: {
+    type: new GraphQLList(GraphQLString),
+  }
+}

--- a/src/__tests__/remove-non-connection-pageable-graphql-lists.test.ts
+++ b/src/__tests__/remove-non-connection-pageable-graphql-lists.test.ts
@@ -1,0 +1,17 @@
+import { defineTest } from "jscodeshift/src/testUtils"
+
+// const consoleLog = console.log
+// beforeAll(() => {
+//   console.log = jest.fn()
+// })
+// afterAll(() => {
+//   console.log = consoleLog
+// })
+
+defineTest(
+  __dirname,
+  "remove-non-connection-pageable-graphql-lists",
+  null,
+  undefined,
+  "ts"
+)

--- a/src/remove-non-connection-pageable-graphql-lists.ts
+++ b/src/remove-non-connection-pageable-graphql-lists.ts
@@ -1,0 +1,100 @@
+/**
+ * 1. Run this codemod, and you likely want to filter out these warnings:
+ *
+ *    ```bash
+ *    $ jscodeshift --extensions=ts --ignore-pattern='src/schema/v2/*' \
+ *                  --transform=../codemods/src/remove-non-connection-pageable-graphql-lists.ts \
+ *                  src/schema \
+ *      | grep -v -E 'spread of.+Field|field config by variable reference|function call `(markdown|initials|amount|filterArtworks|numeral|money)'
+ *    ```
+ *
+ * 3. Run the type-checker and find places where field configs/types were
+ *    emptied but not yet their references: `yarn type-check -w`
+ *
+ * 4. Run the `remove-blank-lines-from-unstaged-changes` script.
+ *
+ * 5. Run prettier: `yarn prettier-project`
+ *
+ * 6. Dump the schema and look for connections not renamed: `yarn dump:local`
+ */
+
+import {
+  Transform,
+  NewExpression,
+  Identifier,
+  ObjectProperty,
+} from "jscodeshift"
+
+import { errorLocation } from "./helpers/errorLocation"
+import { getProperty } from "./helpers/getProperty"
+import {
+  forEachOutputFieldConfigMapProperty,
+  getFieldConfig,
+  getArgumentMap,
+} from "./helpers/graphqlSchemaDefinition"
+
+const transform: Transform = (file, api, _options) => {
+  const j = api.jscodeshift
+  const collection = j(file.source)
+
+  forEachOutputFieldConfigMapProperty(
+    collection,
+    file,
+    (fieldProp, fieldMap) => {
+      const fieldConfig = getFieldConfig(fieldProp, file)
+      if (fieldConfig) {
+        const fieldPropKey = (fieldProp.key as Identifier).name
+
+        const argsProperty = getProperty(fieldConfig, "args")
+        if (argsProperty) {
+          const argsMap = getArgumentMap(argsProperty, file)
+          if (
+            argsMap &&
+            (getProperty(argsMap, "size") || getProperty(argsMap, "limit"))
+          ) {
+            const type = getProperty(fieldConfig, "type")!.value
+            if (
+              NewExpression.check(type) &&
+              (type.callee as Identifier).name === "GraphQLList"
+            ) {
+              const index = fieldMap.properties.findIndex(
+                prop =>
+                  ObjectProperty.check(prop) &&
+                  (prop.key as Identifier).name === fieldPropKey
+              )
+              fieldMap.properties.splice(index, 1)
+            } else {
+              console.log(
+                `Skipping type not defined as GraphQLList inline (${errorLocation(
+                  file,
+                  type
+                )})`
+              )
+            }
+          }
+        }
+
+        const match = fieldPropKey.match(/^(.+?)(_c|C)onnection$/)
+        if (match) {
+          const newName = match[1]
+          console.log(newName)
+          if (!getProperty(fieldMap, newName)) {
+            fieldProp.key = j.identifier(newName)
+          } else {
+            console.log(
+              `Skipping renaming of connection as a field with the new name exists (${errorLocation(
+                file,
+                fieldProp
+              )})`
+            )
+          }
+        }
+      }
+    }
+  )
+
+  return collection.toSource()
+}
+
+export const parser = "ts"
+export default transform


### PR DESCRIPTION
Not 100% sure yet to apply this, but a quick check shows only 3 relay-compiler errors after applying this and for each of those a connection field exists, so not bad.